### PR TITLE
Adds a -Random switch parameter to return a random comic

### DIFF
--- a/PoshBot.Dilbert/PoshBot.Dilbert.psm1
+++ b/PoshBot.Dilbert/PoshBot.Dilbert.psm1
@@ -1,3 +1,14 @@
+function Get-RandomDate {
+    param(
+        [datetime] $Start = 0,
+
+        [datetime] $End = [datetime]::Now
+    )
+
+    $days = (New-TimeSpan -Start $Start -End $End).Days
+    $offset = Get-Random -Minimum 0 -Maximum ($days + 1)
+    (Get-Date).AddDays(-$offset).Date
+}
 
 function Get-Dilbert {
     <#
@@ -16,6 +27,10 @@ function Get-Dilbert {
 
         Get the newest comic
     .EXAMPLE
+        !dilbert -random
+
+        Get a random comic
+    .EXAMPLE
         !dilbert -date 2015-07-04
 
         Get the Dilbert comic published on 2015-07-04
@@ -29,9 +44,13 @@ function Get-Dilbert {
         Get the Dislbert comic including the alternate text for the image.
     #>
     [PoshBot.BotCommand(CommandName = 'dilbert')]
-    [cmdletbinding()]
+    [cmdletbinding(DefaultParameterSetName = 'date')]
     param(
+        [parameter(ParameterSetName = 'date')]
         [datetime]$Date = (Get-Date),
+
+        [parameter(ParameterSetName = 'random')]
+        [switch]$Random,
 
         [switch]$AltText,
 
@@ -41,7 +60,13 @@ function Get-Dilbert {
     $ProgressPreference = 'SilentlyContinue'
     Add-Type -AssemblyName System.Web
 
-    if ($Date -ge [datetime]'1989-04-16') {
+    $firstDilbert = [datetime]'1989-04-16'
+
+    if ($Random) {
+        $Date = Get-RandomDate -Start $firstDilbert
+    }
+
+    if ($Date -ge $firstDilbert) {
 
         if ($Date -gt (Get-Date)) {
             Write-Error 'What are you, from the future?'


### PR DESCRIPTION
Adds a -Random switch parameter to Get-Dilbert. When called with -Random it will return a random comic

## Description
When called with the -Random parameter, a random date between now and '1989-04-16' is used when fetching the comit

## Related Issue
Adds the functionality requested in #2

## Motivation and Context
Not required at all, but nice to be able to get a random comic, similar to what can be done with the XKCD plugin

## How Has This Been Tested?
Simple usage test performed running PoshBot 0.11.5 in PowerShell 5.1 on Windows 10, hooked up to a Slack channel.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
